### PR TITLE
Fix broken link 0.95.9.0

### DIFF
--- a/miranda-ng/tools/chocolateyInstall.ps1
+++ b/miranda-ng/tools/chocolateyInstall.ps1
@@ -1,7 +1,7 @@
 ﻿$packageName = 'miranda-ng'
 $fileType    = 'exe'
-$url         = 'https://www.miranda-ng.org/distr/stable/miranda-ng-v0.95.9.exe'
-$url64       = 'https://www.miranda-ng.org/distr/stable/miranda-ng-v0.95.9_x64.exe'
+$url         = 'https://www.miranda-ng.org/distr/stable/miranda-ng-v0.95.9.1.exe'
+$url64       = 'https://www.miranda-ng.org/distr/stable/miranda-ng-v0.95.9.1_x64.exe'
 $silentArgs  = '/verysilent'
  
 [array]$key = Get-UninstallRegistryKey -SoftwareName "Miranda NG"


### PR DESCRIPTION
At this moment, `choco install miranda-ng` returns 

```
Downloading miranda-ng 64 bit
  from 'https://www.miranda-ng.org/distr/stable/miranda-ng-v0.95.9_x64.exe'
ERROR: The remote file either doesn't exist, is unauthorized, or is forbidden for url 'https://www.miranda-ng.org/distr/stable/miranda-ng-v0.95.9_x64.exe'. Exception calling "GetResponse" with "0" argument(s): "The remote server returned an error: (404) Not Found."
The install of miranda-ng was NOT successful.
Error while running 'C:\ProgramData\chocolatey\lib\miranda-ng\tools\chocolateyInstall.ps1'.
 See log for details.
```

This pull request changes the link to the working one.